### PR TITLE
Version 1.0.19

### DIFF
--- a/TA-jira-service-desk-simple-addon/README/alert_actions.conf.spec
+++ b/TA-jira-service-desk-simple-addon/README/alert_actions.conf.spec
@@ -14,6 +14,7 @@ param.jira_components = <string> JIRA components fields structure, optional.
 param.jira_customfields = <string> JIRA custom fields structure, optional.
 param.jira_customfields_parsing = <boolean> enable or disable parsing of the custom fields, optional.
 param.jira_dedup = <string> JIRA deduplication behaviour, optional.
+param.jira_dedup_exclude_statuses = <string> list of JIRA statuses that will not be considered for comment updates, optional.
 param.jira_attachment = <string> Attach Splunk results to the JIRA issue, optional.
 param.jira_attachment_token = <string> Attach Splunk results to the JIRA issue (token), optional.
 

--- a/TA-jira-service-desk-simple-addon/app.manifest
+++ b/TA-jira-service-desk-simple-addon/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-jira-service-desk-simple-addon",
-      "version": "1.0.18"
+      "version": "1.0.19"
     },
     "author": [
       {

--- a/TA-jira-service-desk-simple-addon/default/alert_actions.conf
+++ b/TA-jira-service-desk-simple-addon/default/alert_actions.conf
@@ -7,6 +7,7 @@ param._cam = {"technology": [{"vendor": "Atlasian", "version": ["1.0"], "product
 param.jira_summary = Splunk Alert: $name$
 param.jira_description = The alert condition for '$name$' was triggered.
 param.jira_attachment_token = $results_file$
+param.jira_dedup_exclude_statuses = Closed,Completed,Canceled
 label = JIRA Service Desk
 payload_format = json
 icon_path = alert_jira_service_desk.png

--- a/TA-jira-service-desk-simple-addon/default/data/ui/alerts/jira_service_desk.html
+++ b/TA-jira-service-desk-simple-addon/default/data/ui/alerts/jira_service_desk.html
@@ -113,6 +113,17 @@
     </div>
 
     <div class="control-group">
+        <label class="control-label" for="jira_service_desk_jira_dedup_exclude_statuses">JIRA dedup excluded statuses </label>
+        <div class="controls">
+            <input type="text" name="action.jira_service_desk.param.jira_dedup_exclude_statuses" id="jira_service_desk_jira_dedup_exclude_statuses"/>
+            <span class="help-block">
+                <br />Comma separated list of Jira statuses that will not be considered for updates, if dedup is enabled and the target issue
+                <br />is in one of these statuses, a new issue will be created instead.
+            </span>
+        </div>
+    </div>
+
+    <div class="control-group">
         <label class="control-label" for="jira_service_desk_jira_attachment">Results attachment: <span class="required">*</span> </label>
         <div class="controls">
     <select name="action.jira_service_desk.param.jira_attachment" id="jira_service_desk_jira_attachment">

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,12 @@
 Release notes
 #############
 
+Version 1.0.19
+==============
+
+- Feature: Issue #33 - Exclude closed statuses from the JIRA dedup behavior, to prevent deduplicating closed issues, which list can be customised if required (defaults to Closed,Completed,Canceled)
+- Feature: Jira get field report split into two reports, one for all projects, one report providing results per project
+
 Version 1.0.18
 ==============
 


### PR DESCRIPTION
- Feature: Issue #33 - Exclude closed statuses from the JIRA dedup behavior, to prevent deduplicating closed issues, which list can be customised if required (defaults to Closed,Completed,Canceled)
- Feature: Jira get field report split into two reports, one for all projects, one report providing results per project