### PR TITLE
Typo in options description

### DIFF
--- a/TA-jira-service-desk-simple-addon/default/data/ui/alerts/jira_service_desk.html
+++ b/TA-jira-service-desk-simple-addon/default/data/ui/alerts/jira_service_desk.html
@@ -105,9 +105,9 @@
                          <br />When a new JIRA issue is created, the issue key reference and it's unique md5 hash are stored in a KVstore.<br />
                          If the jira dedup option is enabled and shall the same issue creation be requested again, a new comment will be added to the existing issue rather than a new issue created.<br />
                          <br />
-                         The md5 hash calculation guarantees the issue unique identification and is performed against the entire issue content.
+                         The md5 hash calculation guarantees the issue unique identification and is performed against the entire issue content. (unless jira_dedup_content is defined)
                          <br /><br />
-                         To define the content of the comment (defaults to: New alert triggered: &lt;issue summary&gt;), generate a field named "jira_update_comment" amd this will be used as the comment automatically.
+                         To define the content of the comment (defaults to: New alert triggered: &lt;issue summary&gt;), generate a field named "jira_update_comment" and this will be used as the comment automatically.
                     </span>
         </div>
     </div>


### PR DESCRIPTION
- In jira dedup option desc, "amd" should be "and"
- Addition of the mention to jira dedup content in the option description