### PR TITLE
Enhancement: jirarest supports additional method for extended JIRA integration

### DIFF
--- a/TA-jira-service-desk-simple-addon/app.manifest
+++ b/TA-jira-service-desk-simple-addon/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-jira-service-desk-simple-addon",
-      "version": "1.0.28"
+      "version": "1.0.29"
     },
     "author": [
       {

--- a/TA-jira-service-desk-simple-addon/bin/jirarest.py
+++ b/TA-jira-service-desk-simple-addon/bin/jirarest.py
@@ -91,6 +91,8 @@ class GenerateTextCommand(GeneratingCommand):
                 raise Exception("jirarest: method {} requires a valid json_request. It is empty".format(jira_method))
 
         if self.target:
+            # set proper headers
+            headers = {'Content-type': 'application/json'}
             if jira_method == "GET":
                 jira_fields_response = requests.get(
                     url=str(url) + '/' + str(self.target),
@@ -105,6 +107,7 @@ class GenerateTextCommand(GeneratingCommand):
                 )
             elif jira_method == "POST":
                 jira_fields_response = requests.post(
+                    headers=headers,
                     url=str(url) + '/' + str(self.target),
                     data=json.dumps(body_dict).encode('utf-8'),
                     auth=(username, password),
@@ -112,13 +115,14 @@ class GenerateTextCommand(GeneratingCommand):
                 )
             elif jira_method == "PUT":
                 jira_fields_response = requests.put(
+                    headers=headers,
                     url=str(url) + '/' + str(self.target),
                     data=json.dumps(body_dict).encode('utf-8'),
                     auth=(username, password),
                     verify=False
                 )
 
-            if jira_fields_response.json() not in [None, '']:
+            if jira_fields_response.json():
                 data = {'_time': time.time(), '_raw': json.dumps(jira_fields_response.json())}
                 yield data
 

--- a/TA-jira-service-desk-simple-addon/bin/jirarest.py
+++ b/TA-jira-service-desk-simple-addon/bin/jirarest.py
@@ -20,17 +20,28 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import ta_jira_service_desk_simple_addon_declare
 from splunklib.searchcommands import dispatch, GeneratingCommand, Configuration, Option, validators
 
+import json
 import sys
 import splunk
 import time
 import requests
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-import json
+
 
 @Configuration(distributed=False)
 class GenerateTextCommand(GeneratingCommand):
 
+    method = Option(
+        doc='''
+        **Syntax:** **method=****
+        **Description:** method to use for API target. DELETE GET POST PUT are supported.''',
+        require=False, validate=validators.Match("method", r"^(DELETE|GET|POST|PUT)$"))
+    json_request = Option(
+        doc='''
+        **Syntax:** **json_request=***JSON request*
+        **Description:** JSON-formatted json_request.''',
+        require=False, validate=validators.Match("json_request", r"^{.+}$"))
     target = Option(require=True)
 
     def jira_url(self, url, endpoint):
@@ -60,27 +71,56 @@ class GenerateTextCommand(GeneratingCommand):
                     if key == "jira_url":
                         url = value
 
+        if not url.startswith("https://"):
+            url = "https://" + str(url)
+
         for credential in storage_passwords:
             if credential.content.get('username') == "additional_parameters``splunk_cred_sep``1" and credential.content.get('clear_password').find('jira_password') > 0:
                 password = json.loads(credential.content.get('clear_password')).get('jira_password')
                 break
 
+        if self.method:
+            jira_method = self.method
+        else:
+            jira_method = "GET"
+
+        if self.json_request:
+            body_dict = json.loads(self.json_request)
+        else:
+            if jira_method == "POST" or jira_method == "PUT":
+                raise Exception("jirarest: method {} requires a valid json_request. It is empty".format(jira_method))
+
         if self.target:
+            if jira_method == "GET":
+                jira_fields_response = requests.get(
+                    url=str(url) + '/' + str(self.target),
+                    auth=(username, password),
+                    verify=False
+                )
+            elif jira_method == "DELETE":
+                jira_fields_response = requests.delete(
+                    url=str(url) + '/' + str(self.target),
+                    auth=(username, password),
+                    verify=False
+                )
+            elif jira_method == "POST":
+                jira_fields_response = requests.post(
+                    url=str(url) + '/' + str(self.target),
+                    data=json.dumps(body_dict).encode('utf-8'),
+                    auth=(username, password),
+                    verify=False
+                )
+            elif jira_method == "PUT":
+                jira_fields_response = requests.put(
+                    url=str(url) + '/' + str(self.target),
+                    data=json.dumps(body_dict).encode('utf-8'),
+                    auth=(username, password),
+                    verify=False
+                )
 
-                if not url.startswith("https://"):
-                    jira_fields_response = requests.get(
-                        url="https://" + str(url) + '/' + str(self.target),
-                        auth=(username, password),
-                        verify=False
-                    )
-                else:
-                    jira_fields_response = requests.get(
-                        url=str(url) + '/' + str(self.target),
-                        auth=(username, password),
-                        verify=False
-                    )
-
+            if jira_fields_response.json() not in [None, '']:
                 data = {'_time': time.time(), '_raw': json.dumps(jira_fields_response.json())}
                 yield data
+
 
 dispatch(GenerateTextCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/TA-jira-service-desk-simple-addon/default/app.conf
+++ b/TA-jira-service-desk-simple-addon/default/app.conf
@@ -7,7 +7,7 @@ build = 1
 
 [launcher]
 author = Guilhem Marchand
-version = 1.0.28
+version = 1.0.29
 description = The JIRA service desk simple addon allows the creation of tickets to Atlassian JIRA Service Desk via a workflow action, which can be actioned via an adaptive response for ES customers.
 
 [ui]

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -283,10 +283,11 @@ How to retrieve the IDs of the custom fields configured ?
    :alt: userguide_getfields2.png
    :align: center
 
-JIRA REST API get wrapper
+JIRA REST API wrapper
 =========================
 
-**A custom command is provided as a generic API wrapper which can be used to get information from JIRA by calling any REST endpoint available:**
+**A custom command is provided as a generic API wrapper which can be used to get information from JIRA by calling any REST endpoint available:**  
+By default, it uses method GET. Additional methods are supported DELETE, POST, PUT.
 
 ::
 
@@ -352,3 +353,35 @@ Each statistic is stored as a metric_name with a prefix "jira\_", while the proj
 .. image:: img/jirarest_004.png
    :alt: jirarest_004.png
    :align: center
+
+
+Additional examples for JIRA API wrapper
+----------------------------------------
+
+Method DELETE: Delete an issue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   | jirarest target="rest/api/2/issue/{issueIdOrKey}" method=DELETE
+
+
+Method POST: Add a comment to an issue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   | jirarest target="rest/api/2/issue/{issueIdOrKey}/comment" method=POST json_request="{
+    \"body\": \"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget venenatis elit. Duis eu justo eget augue iaculis fermentum. Sed semper quam laoreet nisi egestas at posuere augue semper.\",
+    \"visibility\": {
+        \"type\": \"role\",
+        \"value\": \"Administrators\"
+    }"
+   }"
+
+Method PUT: Assign an issue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   | jirarest target="rest/api/2/issue/{issueIdOrKey}/assignee" method=POST json_request="{\"name\": \"harry\"}"


### PR DESCRIPTION
Hello,
first thank you for developing this fantastic TA. very well designed, done and documented. 
I use it a lot to create JIRA issues from notable events and alert action works well for this.
Though I would need jirarest to support more method so JIRA rest API endpoints can be used from Splunk to manage issues. My goal is to have a dashboard to abnalyse notable event and to be able to update JIRA issue directly from it without switching nor copy/paste.

Ideally it would be good to have this command as a streaming command so it can be used in an SPL following this simple use case.
- query Splunk to get some data
- format data under field json_request
- call jira API | jirarest target=  method=<GET|DELETE|POST|PUT>
but it will be manageable if it stays a generating command.

So I don't know if you consider PR but here in short what I would like. I am going to test it anyway on my side.
