### PR TITLE
Version 2.0.1

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,20 @@
 Release notes
 #############
 
+Version 2.0.1
+=============
+
+.. warning:: **BREAKING CHANGES!**
+
+    - The new major release uses a new framework (add-on-ucc-framework) which changes the way accounts are handled by the application
+    - Post upgrade, **you need to setup the connectivity to your JIRA instance(s) again** before the Add-on can be used
+    - Existing alerts will not work anymore until you perform the account setup
+    - You do not need to update the alerts themselves as these remain compatible from version 1.x to version 2.x
+
+**What's new in the Add-on for JIRA version 2.0.x:**
+
+- Fix Appinspect warning check_reload_trigger_for_all_custom_confs #104
+
 Version 2.0.0
 =============
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -693,7 +693,7 @@
         "apiVersion": "3.2.0",
         "name": "TA-jira-service-desk-simple-addon",
         "restRoot": "ta_service_desk_simple_addon",
-        "version": "2.0.0",
+        "version": "2.0.1",
         "displayName": "JIRA Service Desk simple addon",
         "schemaVersion": "0.0.2"
     }

--- a/package/app.manifest
+++ b/package/app.manifest
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "schemaVersion": "2.0.1",
   "info": {
     "title": "JIRA Service Desk simple addon",
     "id": {

--- a/package/default/app.conf
+++ b/package/default/app.conf
@@ -19,9 +19,4 @@ id = TA-jira-service-desk-simple-addon
 check_for_updates = true
 
 [triggers]
-reload.addon_builder = simple
-reload.ta_jira_service_desk_simple_addon_account = simple
-reload.ta_jira_service_desk_simple_addon_settings = simple
-reload.passwords = simple
-
-[id]
+reload.ta_service_desk_simple_addon_settings = simple

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version = 2.0.0
+version = 2.0.1


### PR DESCRIPTION
Version 2.0.1
=============

.. warning:: **BREAKING CHANGES!**

    - The new major release uses a new framework (add-on-ucc-framework) which changes the way accounts are handled by the application
    - Post upgrade, **you need to setup the connectivity to your JIRA instance(s) again** before the Add-on can be used
    - Existing alerts will not work anymore until you perform the account setup
    - You do not need to update the alerts themselves as these remain compatible from version 1.x to version 2.x

**What's new in the Add-on for JIRA version 2.0.x:**

- Fix Appinspect warning check_reload_trigger_for_all_custom_confs #104
