### PR TITLE
Version 2.0.4

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,20 @@
 Release notes
 #############
 
+Version 2.0.4
+=============
+
+.. warning:: **BREAKING CHANGES!**
+
+    - The new major release uses a new framework (add-on-ucc-framework) which changes the way accounts are handled by the application
+    - Post upgrade, **you need to setup the connectivity to your JIRA instance(s) again** before the Add-on can be used
+    - Existing alerts will not work anymore until you perform the account setup
+    - You do not need to update the alerts themselves as these remain compatible from version 1.x to version 2.x
+
+**What's new in the Add-on for JIRA version 2.0.x:**
+
+- Fix: Issue #112 - In release 1.0.x, the priority field was made optional (Issue #42) to address some specific use cases, but this setting was lost during the transition to ucc-libs
+
 Version 2.0.3
 =============
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -471,7 +471,7 @@
                     "valueField": "priorities",
                     "labelField": "priorities",
                     "help": "Select the priority for this issue",
-                    "required": true
+                    "required": false
                 },
                 {
                     "type": "text",
@@ -693,7 +693,7 @@
     "meta": {
         "name": "TA-jira-service-desk-simple-addon",
         "restRoot": "ta_service_desk_simple_addon",
-        "version": "2.0.3",
+        "version": "2.0.4",
         "displayName": "JIRA Service Desk simple addon",
         "schemaVersion": "0.0.3"
     }

--- a/package/app.manifest
+++ b/package/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-jira-service-desk-simple-addon",
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     "author": [
       {

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version = 2.0.3
+version = 2.0.4


### PR DESCRIPTION
- In release 1.0.x, the priority field was made optional (Issue #42) to address some specific use cases, but this setting was lost during the transition to ucc-libs