### PR TITLE
Result alerts in description as table

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -38,9 +38,6 @@
                                     "pattern": "^[a-zA-Z]\\w*$"
                                 }
                             ],
-                            "options": {
-                                "placeholder": "Required"
-                            },
                             "field": "name",
                             "help": "Enter a unique name for this JIRA account.",
                             "required": true
@@ -556,6 +553,10 @@
                             {
                                 "value": "enabled_json",
                                 "label": "Enabled (JSON format)"
+                            },
+                            {
+                                "value": "enabled_table",
+                                "label": "Enabled (Table format)"
                             }
                         ],
                         "display": true

--- a/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
+++ b/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
@@ -40,6 +40,32 @@ def reformat_customfields(i):
 
         return i
 
+# This function is used to format a markdown table from json table in description
+def json_to_jira_table(json_data):
+    # Ensure json_data is a list of dictionaries
+    if isinstance(json_data, dict):
+        json_data = [json_data]
+    
+    if not json_data:
+        return ""
+    
+    # Extract the headers from the keys of the first dictionary
+    headers = json_data[0].keys()
+    
+    # Create the header row in bold
+    #header_row = f"| {' | '.join(headers)} |"
+    header_row = f"| {' | '.join(f'*{header}*' for header in headers)} |"
+                
+    # Create the data rows
+    rows = []
+    for entry in json_data:
+        row = f"| {' | '.join(str(entry.get(header, '')) for header in headers)} |"
+        rows.append(row)
+    
+    # Combine all parts into the final table
+    table = f"{header_row}\n" + "\n".join(rows)
+    
+    return table
 
 # This function can optionnally be used to only remove the espaced double quotes and leave the custom fields with no parsing at all
 def reformat_customfields_minimal(i):
@@ -995,6 +1021,12 @@ def query_url(
                     + search_results_csv
                     + "\n{code}"
                 )
+
+        elif jira_results_description in ("enabled_table"):
+            search_results_json = get_results_json(helper, jira_attachment_token)
+            if search_results_json:
+                search_result_table = json_to_jira_table(json.loads(search_results_json))
+                jira_description = ( jira_description + "\nSplunk search results:\n" + search_result_table )
 
         data["fields"]["description"] = jira_description
 

--- a/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
+++ b/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
@@ -1026,8 +1026,8 @@ def query_url(
             search_results_json = get_results_json(helper, jira_attachment_token)
             if search_results_json:
                 search_result_table = json_to_jira_table(json.loads(search_results_json))
-                jira_description = ( jira_description 
-                    + "\nSplunk search results:\n" 
+                jira_description = ( jira_description
+                    + "\nSplunk search results:\n"
                     + search_result_table )
 
         data["fields"]["description"] = jira_description

--- a/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
+++ b/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
@@ -1026,7 +1026,9 @@ def query_url(
             search_results_json = get_results_json(helper, jira_attachment_token)
             if search_results_json:
                 search_result_table = json_to_jira_table(json.loads(search_results_json))
-                jira_description = ( jira_description + "\nSplunk search results:\n" + search_result_table )
+                jira_description = ( jira_description 
+                    + "\nSplunk search results:\n" 
+                    + search_result_table )
 
         data["fields"]["description"] = jira_description
 

--- a/package/default/data/ui/alerts/jira_service_desk.html
+++ b/package/default/data/ui/alerts/jira_service_desk.html
@@ -132,6 +132,7 @@
         <option value="disabled">Disabled</option>
         <option value="enabled_json">Enabled (JSON format)</option>
         <option value="enabled_csv">Enabled (CSV format)</option>
+        <option value="enabled_table">Enabled (Table format)</option>
       </select>
       <span class="help-block">
         <br />Enable this option to automatically add the Splunk results as

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 splunk-add-on-ucc-framework>=5.44.0
+requests


### PR DESCRIPTION
Hi all,

we had the same issue as descripted [here](https://github.com/guilhemmarchand/TA-jira-service-desk-simple-addon/issues/193) and would like to render the results as markdown table instead of csv or json. 

