### PR TITLE
Fix issue dedup being broken on JIRA Cloud due to Jira API Changes

### DIFF
--- a/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
+++ b/package/bin/ta_service_desk_simple_addon/modalert_jira_service_desk_helper.py
@@ -1185,7 +1185,6 @@ def query_url(
                         jira_url_status,
                         "GET",
                         parameters=None,
-                        payload=data,
                         headers=jira_headers,
                         cookies=None,
                         verify=ssl_certificate_validation,


### PR DESCRIPTION
closes #200 

Looks like this get request was copy pasted from one of the other POST requests and it was incorrectly sending the contents of the issue. 

At some point, atlassian put the Jira Cloud API behind cloudfront, and it just auto blocks any requests that do this.

> UPDATE 25/1/25: Jira Cloud now uses AWS Cloudfront. AWS Cloudfront blocks GET requests with a Body payload. See  https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustom-get-body  Most commonly we see API clients and integrations sending {} [] "" '' . Please ensure your API client does not include a body with a GET request. This information only applies to API clients, not browsers.