### PR TITLE
Fix/splunk cloud precheck py313

### DIFF
--- a/package/bin/jira_service_rest_handler.py
+++ b/package/bin/jira_service_rest_handler.py
@@ -21,7 +21,7 @@ splunkhome = os.environ["SPLUNK_HOME"]
 
 # append lib
 sys.path.append(
-    os.path.join(splunkhome, "etc", "apps", "TA-jira-service-desk-simple-addon", "lib")
+    os.path.join(splunkhome, "etc", "apps", "TA-jira-service-desk-simple-addon-local", "lib")
 )
 
 # import libs
@@ -102,13 +102,13 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon",
+            app="TA-jira-service-desk-simple-addon-local",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set and get conf
-        conf_file = "ta_service_desk_simple_addon_settings"
+        conf_file = "ta_service_desk_simple_addon_local_settings"
         confs = service.confs[str(conf_file)]
 
         # Initialize the jira_service_desk dictionary
@@ -158,7 +158,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
                             # get proxy password, if any
                             storage_passwords = service.storage_passwords
-                            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_settings"
+                            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_settings"
                             for credential in storage_passwords:
                                 if (
                                     credential.content.get("realm")
@@ -255,14 +255,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon",
+            app="TA-jira-service-desk-simple-addon-local",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_settings"
+        conf_file = "ta_service_desk_simple_addon_local_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -273,7 +273,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
         # get all acounts
         accounts = []
-        conf_file = "ta_service_desk_simple_addon_account"
+        conf_file = "ta_service_desk_simple_addon_local_account"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             # get all accounts
@@ -742,14 +742,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon",
+            app="TA-jira-service-desk-simple-addon-local",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_settings"
+        conf_file = "ta_service_desk_simple_addon_local_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -763,7 +763,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
         # get all acounts
         accounts = []
-        conf_file = "ta_service_desk_simple_addon_account"
+        conf_file = "ta_service_desk_simple_addon_local_account"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             # get all accounts
@@ -822,7 +822,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
             # realm
             credential_username = f"{str(account)}``splunk_cred_sep``1"
-            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_account"
+            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_account"
 
             for credential in storage_passwords:
                 if credential.content.get("username") == str(
@@ -901,14 +901,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon",
+            app="TA-jira-service-desk-simple-addon-local",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_settings"
+        conf_file = "ta_service_desk_simple_addon_local_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -926,7 +926,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # The bearer token is stored in the credential store
         # However, likely due to the number of chars, the credential.content.get SDK command is unable to return its value in a single operation
         # As a workaround, we concatenate the different values return to form a complete object, finally we use a regex approach to extract its clear text value
-        credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_settings"
+        credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_settings"
         bearer_token_rawvalue = ""
 
         for credential in storage_passwords:
@@ -937,7 +937,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
         # extract a clean json object
         bearer_token_rawvalue_match = re.search(
-            '\{"bearer_token":\s*"(.*)"\}', bearer_token_rawvalue
+            r'\{"bearer_token":\s*"(.*)"\}', bearer_token_rawvalue
         )
         if bearer_token_rawvalue_match:
             bearer_token = bearer_token_rawvalue_match.group(1)

--- a/package/bin/jira_service_rest_handler.py
+++ b/package/bin/jira_service_rest_handler.py
@@ -21,7 +21,7 @@ splunkhome = os.environ["SPLUNK_HOME"]
 
 # append lib
 sys.path.append(
-    os.path.join(splunkhome, "etc", "apps", "TA-jira-service-desk-simple-addon-local", "lib")
+    os.path.join(splunkhome, "etc", "apps", "TA-jira-service-desk-simple-addon", "lib")
 )
 
 # import libs
@@ -102,13 +102,13 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon-local",
+            app="TA-jira-service-desk-simple-addon",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set and get conf
-        conf_file = "ta_service_desk_simple_addon_local_settings"
+        conf_file = "ta_service_desk_simple_addon_settings"
         confs = service.confs[str(conf_file)]
 
         # Initialize the jira_service_desk dictionary
@@ -158,7 +158,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
                             # get proxy password, if any
                             storage_passwords = service.storage_passwords
-                            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_settings"
+                            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_settings"
                             for credential in storage_passwords:
                                 if (
                                     credential.content.get("realm")
@@ -255,14 +255,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon-local",
+            app="TA-jira-service-desk-simple-addon",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_local_settings"
+        conf_file = "ta_service_desk_simple_addon_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -273,7 +273,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
         # get all acounts
         accounts = []
-        conf_file = "ta_service_desk_simple_addon_local_account"
+        conf_file = "ta_service_desk_simple_addon_account"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             # get all accounts
@@ -742,14 +742,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon-local",
+            app="TA-jira-service-desk-simple-addon",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_local_settings"
+        conf_file = "ta_service_desk_simple_addon_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -763,7 +763,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
         # get all acounts
         accounts = []
-        conf_file = "ta_service_desk_simple_addon_local_account"
+        conf_file = "ta_service_desk_simple_addon_account"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             # get all accounts
@@ -822,7 +822,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
 
             # realm
             credential_username = f"{str(account)}``splunk_cred_sep``1"
-            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_account"
+            credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_account"
 
             for credential in storage_passwords:
                 if credential.content.get("username") == str(
@@ -901,14 +901,14 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # Get service
         service = client.connect(
             owner="nobody",
-            app="TA-jira-service-desk-simple-addon-local",
+            app="TA-jira-service-desk-simple-addon",
             port=request_info.server_rest_port,
             token=request_info.system_authtoken,
         )
 
         # set loglevel
         loglevel = "INFO"
-        conf_file = "ta_service_desk_simple_addon_local_settings"
+        conf_file = "ta_service_desk_simple_addon_settings"
         confs = service.confs[str(conf_file)]
         for stanza in confs:
             if stanza.name == "logging":
@@ -926,7 +926,7 @@ class Jira_v1(jira_rest_handler.RESTHandler):
         # The bearer token is stored in the credential store
         # However, likely due to the number of chars, the credential.content.get SDK command is unable to return its value in a single operation
         # As a workaround, we concatenate the different values return to form a complete object, finally we use a regex approach to extract its clear text value
-        credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon-local#configs/conf-ta_service_desk_simple_addon_local_settings"
+        credential_realm = "__REST_CREDENTIAL__#TA-jira-service-desk-simple-addon#configs/conf-ta_service_desk_simple_addon_settings"
         bearer_token_rawvalue = ""
 
         for credential in storage_passwords:

--- a/package/default/alert_actions.conf
+++ b/package/default/alert_actions.conf
@@ -6,6 +6,7 @@ label = Open/Update/Close an issue in JIRA
 description = This modular alert action allows you to interact with JIRA, to open, update or close an issue.
 param._cam = {"task": ["Create", "Update", "Close"], "subject": ["incident"], "category": ["Ticketing system", "Incident management"], "technology": [{"version": ["1.0.0"], "product": "JIRA Service Desk", "vendor": "Atlasian"}], "supports_adhoc": true, "drilldown_uri": "search?q=search%20index%3D_internal%20OR%20index%3Dcim_modaction%20sourcetype%3Djira%3Aservice_desk_alert_action&earliest=0&latest="}
 python.version = python3
+python.required = 3.13
 is_custom = 1
 payload_format = json
 param.account = 
@@ -39,6 +40,7 @@ icon_path = alert_jira_service_desk.png
 label = Replay an issue in JIRA
 description = This modular alert action allows you to replay an issue in JIRA, which had previously failed to be created for any temporary reasons, such as networking issues or temporary unavailability of the JIRA server.
 python.version = python3
+python.required = 3.13
 is_custom = 0
 payload_format = json
 param.account = 

--- a/package/default/commands.conf
+++ b/package/default/commands.conf
@@ -7,6 +7,7 @@
  chunked = true
  filename = jirafill.py
  python.version = python3
+ python.required = 3.13
 
 # generic rest wrapper, get any info using a rest endpoint
 
@@ -14,6 +15,7 @@
  chunked = true
  filename = jirarest.py
  python.version = python3
+ python.required = 3.13
 
 # load replay KVstore content, used to handle distributed setup and replay KVstore purposes
 
@@ -21,6 +23,7 @@
  chunked = true
  filename = getjirakv.py
  python.version = python3
+ python.required = 3.13
 
 # jira overview statistics
 
@@ -28,6 +31,7 @@
  chunked = true
  filename = jiraoverview.py
  python.version = python3
+ python.required = 3.13
 
 # A simple streaming command to expand a JSON response
 
@@ -35,3 +39,4 @@
  chunked = true
  filename = jirajsonexpand.py
  python.version = python3
+ python.required = 3.13

--- a/package/default/restmap.conf
+++ b/package/default/restmap.conf
@@ -4,23 +4,23 @@
 # Splunk UCC
 #
 
-[admin:ta_service_desk_simple_addon_local]
+[admin:ta_service_desk_simple_addon]
 match = /
-members = ta_service_desk_simple_addon_local_account, ta_service_desk_simple_addon_local_settings
+members = ta_service_desk_simple_addon_account, ta_service_desk_simple_addon_settings
 
-[admin_external:ta_service_desk_simple_addon_local_account]
+[admin_external:ta_service_desk_simple_addon_account]
 handlertype = python
 python.version = python3
 python.required = 3.13
-handlerfile = ta_service_desk_simple_addon_local_rh_account.py
+handlerfile = ta_service_desk_simple_addon_rh_account.py
 handleractions = edit, list, remove, create
 handlerpersistentmode = true
 
-[admin_external:ta_service_desk_simple_addon_local_settings]
+[admin_external:ta_service_desk_simple_addon_settings]
 handlertype = python
 python.version = python3
 python.required = 3.13
-handlerfile = ta_service_desk_simple_addon_local_rh_settings.py
+handlerfile = ta_service_desk_simple_addon_rh_settings.py
 handleractions = edit, list
 handlerpersistentmode = true
 

--- a/package/default/restmap.conf
+++ b/package/default/restmap.conf
@@ -4,21 +4,23 @@
 # Splunk UCC
 #
 
-[admin:ta_service_desk_simple_addon]
+[admin:ta_service_desk_simple_addon_local]
 match = /
-members = ta_service_desk_simple_addon_account, ta_service_desk_simple_addon_settings
+members = ta_service_desk_simple_addon_local_account, ta_service_desk_simple_addon_local_settings
 
-[admin_external:ta_service_desk_simple_addon_account]
+[admin_external:ta_service_desk_simple_addon_local_account]
 handlertype = python
 python.version = python3
-handlerfile = ta_service_desk_simple_addon_rh_account.py
+python.required = 3.13
+handlerfile = ta_service_desk_simple_addon_local_rh_account.py
 handleractions = edit, list, remove, create
 handlerpersistentmode = true
 
-[admin_external:ta_service_desk_simple_addon_settings]
+[admin_external:ta_service_desk_simple_addon_local_settings]
 handlertype = python
 python.version = python3
-handlerfile = ta_service_desk_simple_addon_rh_settings.py
+python.required = 3.13
+handlerfile = ta_service_desk_simple_addon_local_rh_settings.py
 handleractions = edit, list
 handlerpersistentmode = true
 
@@ -36,3 +38,4 @@ passPayload           = true
 passSystemAuth        = true
 capability            = jira_service_desk
 python.version = python3
+python.required = 3.13


### PR DESCRIPTION
### Summary

Two minimal changes that make the add-on pass Splunk Cloud's Pre-Check on Splunk Enterprise 10.2+ stacks (where Python 3.13 is the runtime). Both are backward-compatible — older stacks continue to work unchanged.

### Change 1: Add `python.required = 3.13` alongside `python.version = python3` (10 stanzas)

On Splunk 10.2+, Cloud Pre-Check rejects apps that only declare the deprecated `python.version` directive. Splunk's official guidance for the deprecation phase is to set both: legacy engines read `python.version`, current engines read `python.required` (which takes precedence per the spec).

Affected stanzas:

- `package/default/alert_actions.conf`: `[jira_service_desk]`, `[jira_service_desk_replay]`
- `package/default/commands.conf`: `[jirafill]`, `[jirarest]`, `[getjirakv]`, `[jiraoverview]`, `[jirajsonexpand]`
- `package/default/restmap.conf`: `[admin_external:ta_service_desk_simple_addon_account]`, `[admin_external:ta_service_desk_simple_addon_settings]`, `[script:jira_service_rest_handler]`

`3.13` chosen because it is the only non-deprecated value Splunk 10.2+ accepts for `python.required` (allowed values per spec: `3.9`, `3.13`, `latest`). The codebase has no 3.10+/3.13-specific syntax features, so it runs unchanged on 3.13.

### Change 2: Fix `SyntaxWarning: invalid escape sequence '\{'` in `jira_service_rest_handler.py`

Python 3.12+ promotes invalid escape sequences from silent acceptance to `SyntaxWarning`, and 3.14 will make them a `SyntaxError`. The regex pattern at line 940 used a regular string literal with `\{`, `\}`, `\s` escapes:

```python
re.search('\{"bearer_token":\s*"(.*)"\}', ...)
```

Converted to a raw string literal — semantically identical, no warning:

```python
re.search(r'\{"bearer_token":\s*"(.*)"\}', ...)
```

On 10.2+ this otherwise floods `splunkd.log` with `ERROR PersistentScript` entries on every REST handler invocation (every search edit when an alert action is bound to the saved search).

### Validation

Local AppInspect with `--included-tags cloud` on the patched package:

```
failures:       0
errors:         0
manual_checks:  0
future_failure: 0
warnings:       15  (informational only — telemetry, deprecated splunkjs/mvc/headerview, etc.)
```

Tested by installing on a Splunk Cloud Victoria 10.2+ stack: ticket creation and bidirectional sync work as before; no more `SyntaxWarning` entries in `splunkd.log`.

### Diff stats

4 files changed, 10 insertions(+), 1 deletion(-)
